### PR TITLE
Add Active Directory compatibility

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -59,5 +59,6 @@ return array(
         'ldap_auth_lastname_attribute' => 'sn',
         'ldap_auth_fullname_attribute' => 'displayname',
         'ldap_auth_isactivedirectory' => false,
+        'ldap_auth_activedirectory_domain' => null,
     )
 );

--- a/Config/config.php
+++ b/Config/config.php
@@ -58,5 +58,6 @@ return array(
         'ldap_auth_firstname_attribute' => 'givenname',
         'ldap_auth_lastname_attribute' => 'sn',
         'ldap_auth_fullname_attribute' => 'displayname',
+        'ldap_auth_isactivedirectory' => false,
     )
 );

--- a/EventListener/UserSubscriber.php
+++ b/EventListener/UserSubscriber.php
@@ -108,6 +108,7 @@ class UserSubscriber implements EventSubscriberInterface
             'user_firstname'=> $this->parametersHelper->getParameter('ldap_auth_firstname_attribute', 'givenName'),
             'user_lastname' => $this->parametersHelper->getParameter('ldap_auth_lastname_attribute', 'sn'),
             'user_fullname' => $this->parametersHelper->getParameter('ldap_auth_fullname_attribute', 'displayName'),
+            'isactivedirectory' => $this->parametersHelper->getParameter('ldap_auth_isactivedirectory', false),
         ];
 
         $parameters = [

--- a/EventListener/UserSubscriber.php
+++ b/EventListener/UserSubscriber.php
@@ -109,6 +109,7 @@ class UserSubscriber implements EventSubscriberInterface
             'user_lastname' => $this->parametersHelper->getParameter('ldap_auth_lastname_attribute', 'sn'),
             'user_fullname' => $this->parametersHelper->getParameter('ldap_auth_fullname_attribute', 'displayName'),
             'isactivedirectory' => $this->parametersHelper->getParameter('ldap_auth_isactivedirectory', false),
+            'activedirectory_domain' => $this->parametersHelper->getParameter('ldap_auth_activedirectory_domain', null),
         ];
 
         $parameters = [

--- a/Form/Type/ConfigType.php
+++ b/Form/Type/ConfigType.php
@@ -212,6 +212,19 @@ class ConfigType extends AbstractType
                 'required' => false,
             ]
         );
+        $builder->add(
+            'ldap_auth_isactivedirectory',
+            TextType::class,
+            [
+                'label'      => 'mautic.integration.sso.ldapauth.config.form.isactivedirectory',
+                'label_attr' => ['class' => 'control-label'],
+                'attr'       => [
+                    'class' => 'form-control',
+                ],
+                'empty_data' => 'false',
+                'required' => false,
+            ]
+        );
     }
 
     /**

--- a/Form/Type/ConfigType.php
+++ b/Form/Type/ConfigType.php
@@ -225,6 +225,19 @@ class ConfigType extends AbstractType
                 'required' => false,
             ]
         );
+        $builder->add(
+            'ldap_auth_activedirectory_domain',
+            TextType::class,
+            [
+                'label'      => 'mautic.integration.sso.ldapauth.config.form.activedirectory_domain',
+                'label_attr' => ['class' => 'control-label'],
+                'attr'       => [
+                    'class' => 'form-control',
+                ],
+                'empty_data' => 'false',
+                'required' => false,
+            ]
+        );
     }
 
     /**

--- a/Integration/LdapAuthIntegration.php
+++ b/Integration/LdapAuthIntegration.php
@@ -99,6 +99,7 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
         $query = $settings['user_query'];
         $password = $parameters['password'];
         $isactivedirectory = $settings['isactivedirectory'];
+        $activedirectory_dn = $settings['activedirectory_domain'];
 
         if (substr($hostname, 0, 8) === 'ldaps://') {
             $ssl = true;
@@ -127,17 +128,21 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
 
             try {
                 if ($isactivedirectory) {
-                    $patterns = array();
+
+                    /*$patterns = array();
                     $patterns[0] = '/[,]/';
                     $patterns[1] = '/DC=|dc=|d=/';
                     $patterns[2] = '/\w{1,2}=\w+\./'; // delete all other common names and attributes
                     $replacements = array();
                     $replacements[0] = '.'; // the only actual replacement
-                    $parsed_dn = preg_replace($patterns, $replacements, $base_dn);
-                    $dn = "$login@$parsed_dn";
+                    $parsed_dn = preg_replace($patterns, $replacements, $base_dn); */
+
+                    $dn = "$login@$activedirectory_dn";
+
                 } else {
                     $dn = "$userKey=$login,$base_dn";
                 }
+
 
                 $userquery = "$userKey=$login";
                 $query = "(&($userquery)$query)"; // original $query already has brackets!

--- a/Integration/LdapAuthIntegration.php
+++ b/Integration/LdapAuthIntegration.php
@@ -89,12 +89,15 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
     public function authCallback($settings = [], $parameters = [])
     {
         $hostname = $settings['hostname'];
-        $port = isset($settings['port']) ? (int) $settings['port'] : 389;
-        $ssl = isset($settings['ssl']) ? (bool) $settings['ssl'] : false;
-        $startTls = isset($settings['starttls']) ? (bool) $settings['starttls'] : false;
+        $port = isset($settings['port']) ? (int)$settings['port'] : 389;
+        $ssl = isset($settings['ssl']) ? (bool)$settings['ssl'] : false;
+        $startTls = isset($settings['starttls']) ? (bool)$settings['starttls'] : false;
         $ldapVersion = isset($settings['version']) && !empty($settings['version']) ?
-            (int) $settings['version'] : 3;
+            (int)$settings['version'] : 3;
         $base_dn = $settings['base_dn'];
+        $userKey = $settings['user_key'];
+        $query = $settings['user_query'];
+        $isactivedirectory = $settings['isactivedirectory'];
 
         if (substr($hostname, 0, 8) === 'ldaps://') {
             $ssl = true;
@@ -122,11 +125,22 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
             $ldap = new LdapClient($hostname, $port, $ldapVersion, $ssl, $startTls);
 
             try {
-                $userKey = $settings['user_key'];
-                $query = $settings['user_query'];
+                if ($isactivedirectory) {
+                    $patterns = array();
+                    $patterns[0] = '/[,]/';
+                    $patterns[1] = '/DC=|dc=|d=/';
+                    $patterns[2] = '/\w{1,2}=\w+\./'; // delete all other common names and attributes
+                    $replacements = array();
+                    $replacements[0] = '.'; // the only actual replacement
+                    $parsed_dn = preg_replace($patterns, $replacements, $base_dn);
+                    $dn = "$login@$parsed_dn";
 
-                $dn = "$userKey=$login,$base_dn";
-                $password = $parameters['password'];
+                    $userquery = "$userKey=$login";
+                    $query = "(&($userquery)$query)"; // original $query already has brackets!
+                } else {
+                    $dn = "$userKey=$login,$base_dn";
+                    $password = $parameters['password'];
+                }
 
                 $ldap->bind($dn, $password);
                 $response = $ldap->find($dn, $query);
@@ -273,8 +287,8 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
      * {@inheritdoc}
      *
      * @param Form|\Symfony\Component\Form\FormBuilder $builder
-     * @param array                                    $data
-     * @param string                                   $formArea
+     * @param array $data
+     * @param string $formArea
      */
     public function appendToForm(&$builder, $data, $formArea)
     {
@@ -284,8 +298,8 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
                 'yesno_button_group',
                 [
                     'label' => 'mautic.integration.sso.ldapauth.auth_fallback',
-                    'data'  => (isset($data['auth_fallback'])) ? (bool) $data['auth_fallback'] : true,
-                    'attr'  => [
+                    'data' => (isset($data['auth_fallback'])) ? (bool)$data['auth_fallback'] : true,
+                    'attr' => [
                         'tooltip' => 'mautic.integration.sso.ldapauth.auth_fallback.tooltip',
                     ],
                 ]
@@ -296,8 +310,8 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
                 'yesno_button_group',
                 [
                     'label' => 'mautic.integration.sso.auto_create_user',
-                    'data'  => (isset($data['auto_create_user'])) ? (bool) $data['auto_create_user'] : false,
-                    'attr'  => [
+                    'data' => (isset($data['auto_create_user'])) ? (bool)$data['auto_create_user'] : false,
+                    'attr' => [
                         'tooltip' => 'mautic.integration.sso.auto_create_user.tooltip',
                     ],
                 ]
@@ -307,10 +321,10 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
                 'new_user_role',
                 'role_list',
                 [
-                    'label'      => 'mautic.integration.sso.new_user_role',
+                    'label' => 'mautic.integration.sso.new_user_role',
                     'label_attr' => ['class' => 'control-label'],
-                    'attr'       => [
-                        'class'   => 'form-control',
+                    'attr' => [
+                        'class' => 'form-control',
                         'tooltip' => 'mautic.integration.sso.new_user_role.tooltip',
                     ],
                 ]

--- a/Integration/LdapAuthIntegration.php
+++ b/Integration/LdapAuthIntegration.php
@@ -97,6 +97,7 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
         $base_dn = $settings['base_dn'];
         $userKey = $settings['user_key'];
         $query = $settings['user_query'];
+        $password = $parameters['password'];
         $isactivedirectory = $settings['isactivedirectory'];
 
         if (substr($hostname, 0, 8) === 'ldaps://') {
@@ -134,16 +135,15 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
                     $replacements[0] = '.'; // the only actual replacement
                     $parsed_dn = preg_replace($patterns, $replacements, $base_dn);
                     $dn = "$login@$parsed_dn";
-
-                    $userquery = "$userKey=$login";
-                    $query = "(&($userquery)$query)"; // original $query already has brackets!
                 } else {
                     $dn = "$userKey=$login,$base_dn";
-                    $password = $parameters['password'];
                 }
 
+                $userquery = "$userKey=$login";
+                $query = "(&($userquery)$query)"; // original $query already has brackets!
+
                 $ldap->bind($dn, $password);
-                $response = $ldap->find($dn, $query);
+                $response = $ldap->find($base_dn, $query);
                 // If we reach this far, we expect to have found something
                 // and join the settings to the response to retrieve user fields
                 if (is_array($response)) {

--- a/Integration/LdapAuthIntegration.php
+++ b/Integration/LdapAuthIntegration.php
@@ -128,21 +128,10 @@ class LdapAuthIntegration extends AbstractSsoFormIntegration
 
             try {
                 if ($isactivedirectory) {
-
-                    /*$patterns = array();
-                    $patterns[0] = '/[,]/';
-                    $patterns[1] = '/DC=|dc=|d=/';
-                    $patterns[2] = '/\w{1,2}=\w+\./'; // delete all other common names and attributes
-                    $replacements = array();
-                    $replacements[0] = '.'; // the only actual replacement
-                    $parsed_dn = preg_replace($patterns, $replacements, $base_dn); */
-
                     $dn = "$login@$activedirectory_dn";
-
                 } else {
                     $dn = "$userKey=$login,$base_dn";
                 }
-
 
                 $userquery = "$userKey=$login";
                 $query = "(&($userquery)$query)"; // original $query already has brackets!

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A sample configuration for Active Directory is
         'ldap_auth_lastname_attribute' => 'sn',
         'ldap_auth_fullname_attribute' => 'displayname',
         'ldap_auth_isactivedirectory' => true,
-        'ldap_auth_activedirectory_domain' => 'ad.mysupercompany.com'
+        'ldap_auth_activedirectory_domain' => 'ad.mysupercompany.com',
     // ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,14 +47,15 @@ A sample configuration for Active Directory is
         'ldap_auth_version' => 3,
         'ldap_auth_ssl' => false,
         'ldap_auth_starttls' => false,
-        'ldap_auth_base_dn' => 'cn=Users,dc=ldap,dc=mysupercompany,dc=com',
+        'ldap_auth_base_dn' => 'cn=Users,dc=ad,dc=mysupercompany,dc=com',
         'ldap_auth_user_query' => '(objectclass=user)(memberof=marketing)',     // careful this can be case sensitive!
-        'ldap_auth_username_attribute' => 'samaccountname', // this is case sensitive!
+        'ldap_auth_username_attribute' => 'samaccountname',                     // this is case sensitive!
         'ldap_auth_email_attribute' => 'mail',
         'ldap_auth_firstname_attribute' => 'givenname',
         'ldap_auth_lastname_attribute' => 'sn',
         'ldap_auth_fullname_attribute' => 'displayname',
         'ldap_auth_isactivedirectory' => true,
+        'ldap_auth_activedirectory_domain' => 'ad.mysupercompany.com'
     // ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Edit manually your parameters in `local.php` (adapt to your LDAP configuration):
         'ldap_auth_firstname_attribute' => 'givenname',
         'ldap_auth_lastname_attribute' => 'sn',
         'ldap_auth_fullname_attribute' => 'displayname',
+        'ldap_auth_isactivedirectory' => true,
     // ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A sample configuration for Active Directory is
         'ldap_auth_ssl' => false,
         'ldap_auth_starttls' => false,
         'ldap_auth_base_dn' => 'cn=Users,dc=ldap,dc=mysupercompany,dc=com',
-        'ldap_auth_user_query' => '(objectclass=user)',     // careful this can be case sensitive!
+        'ldap_auth_user_query' => '(objectclass=user)(memberof=marketing)',     // careful this can be case sensitive!
         'ldap_auth_username_attribute' => 'samaccountname', // this is case sensitive!
         'ldap_auth_email_attribute' => 'mail',
         'ldap_auth_firstname_attribute' => 'givenname',

--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ Edit manually your parameters in `local.php` (adapt to your LDAP configuration):
         'ldap_auth_firstname_attribute' => 'givenname',
         'ldap_auth_lastname_attribute' => 'sn',
         'ldap_auth_fullname_attribute' => 'displayname',
+        'ldap_auth_isactivedirectory' => false,
+    // ...
+```
+
+A sample configuration for Active Directory is 
+```php
+    //'parameters' => array(
+    // ...
+        'ldap_auth_host' => 'ad.mysupercompany.com',
+        'ldap_auth_port' => 389,
+        'ldap_auth_version' => 3,
+        'ldap_auth_ssl' => false,
+        'ldap_auth_starttls' => false,
+        'ldap_auth_base_dn' => 'cn=Users,dc=ldap,dc=mysupercompany,dc=com',
+        'ldap_auth_user_query' => '(objectclass=user)',     // careful this can be case sensitive!
+        'ldap_auth_username_attribute' => 'samaccountname', // this is case sensitive!
+        'ldap_auth_email_attribute' => 'mail',
+        'ldap_auth_firstname_attribute' => 'givenname',
+        'ldap_auth_lastname_attribute' => 'sn',
+        'ldap_auth_fullname_attribute' => 'displayname',
         'ldap_auth_isactivedirectory' => true,
     // ...
 ```

--- a/Translations/en_US/messages.ini
+++ b/Translations/en_US/messages.ini
@@ -27,4 +27,5 @@ mautic.integration.sso.ldapauth.config.form.email_attribute="LDAP email attribut
 mautic.integration.sso.ldapauth.config.form.firstname_attribute="LDAP firstname attribute (usually givenname)"
 mautic.integration.sso.ldapauth.config.form.lastname_attribute="LDAP lastname to match (usually sn)"
 mautic.integration.sso.ldapauth.config.form.fullname_attribute="LDAP full name to match (usually displayname)"
-mautic.integration.sso.ldapauth.config.form.isactivedirectory="LDAP uses Microsoft ActiveDirectory compatible syntax"
+mautic.integration.sso.ldapauth.config.form.isactivedirectory="LDAP use Active Directory_Domain parameter to bind to LDAP"
+mautic.integration.sso.ldapauth.config.form.activedirectory_domain="Use Active Directory compatible distinguished name syntax"

--- a/Translations/en_US/messages.ini
+++ b/Translations/en_US/messages.ini
@@ -27,3 +27,4 @@ mautic.integration.sso.ldapauth.config.form.email_attribute="LDAP email attribut
 mautic.integration.sso.ldapauth.config.form.firstname_attribute="LDAP firstname attribute (usually givenname)"
 mautic.integration.sso.ldapauth.config.form.lastname_attribute="LDAP lastname to match (usually sn)"
 mautic.integration.sso.ldapauth.config.form.fullname_attribute="LDAP full name to match (usually displayname)"
+mautic.integration.sso.ldapauth.config.form.isactivedirectory="LDAP uses Microsoft ActiveDirectory compatible syntax"

--- a/Views/FormTheme/Config/_config_ldapconfig_widget.php
+++ b/Views/FormTheme/Config/_config_ldapconfig_widget.php
@@ -89,6 +89,11 @@ $fieldKeys = array_keys($fields);
                     <?php echo $view['form']->row($fields['ldap_auth_isactivedirectory']); ?>
                 </div>
             </div>
+            <div class="row">
+                <div class="col-md-6">
+                    <?php echo $view['form']->row($fields['ldap_auth_activedirectory_domain']); ?>
+                </div>
+            </div>
         </div>
     </div>
 <?php endif; ?>

--- a/Views/FormTheme/Config/_config_ldapconfig_widget.php
+++ b/Views/FormTheme/Config/_config_ldapconfig_widget.php
@@ -84,6 +84,11 @@ $fieldKeys = array_keys($fields);
                     <?php echo $view['form']->row($fields['ldap_auth_fullname_attribute']); ?>
                 </div>
             </div>
+            <div class="row">
+                <div class="col-md-6">
+                    <?php echo $view['form']->row($fields['ldap_auth_isactivedirectory']); ?>
+                </div>
+            </div>
         </div>
     </div>
 <?php endif; ?>


### PR DESCRIPTION
Fixes #1

Added Active Directory compatibility, which can be triggered using the `ldap_auth_isactivedirectory` option in `local.php`. Default is set to `false`.

As discussed in the issue Active Directory does not accept the binding name that was used in the previous implementation. If `isactivedirectory` is set to true the plugin will parse the binding name like `userkey@ad.example.com`, while the userkey usually is `samaccountname` for AD.
Regular expressions are used to parse the parameter `ldap_auth_base_dn` to e.g. 
```
OU=User,DC=ad,DC=example,DC=com        ==>         ad.example.com
```
Also other semantics like `d=` or `dc=` are respected in parsing

Tested with my companies Active Directory (config not included for obvious reasons) and OpenLDAP test server of ldap.forumsys.com using this config:
```
        'ldap_auth_host' => '54.196.176.103',
        'ldap_auth_port' => 389,
        'ldap_auth_version' => 3,
        'ldap_auth_ssl' => false,
        'ldap_auth_starttls' => false,
        'ldap_auth_base_dn' => 'dc=example,dc=com',
        'ldap_auth_user_query' => '(objectclass=inetOrgPerson)',
        'ldap_auth_username_attribute' => 'uid',
        'ldap_auth_email_attribute' => 'mail',
        'ldap_auth_firstname_attribute' => 'sn',
        'ldap_auth_lastname_attribute' => 'sn',
        'ldap_auth_fullname_attribute' => 'cn',
	'ldap_auth_isactivedirectory' => false,
```

Important: If one needs multiple filter queries it is required now to write them in this way:  `'ldap_auth_user_query' => '(objectclass=inetOrgPerson)(organizationalunit=scientists)',`