### PR TITLE
Mautic 4 support (update ldap code to use symfony/ldap 4.4)

### DIFF
--- a/Form/Type/ConfigType.php
+++ b/Form/Type/ConfigType.php
@@ -98,7 +98,6 @@ class ConfigType extends AbstractType
                             'ldaps://' === substr($options['data']['ldap_auth_host'], 0, 8)
                             : false
                     ),
-                'empty_data' => false,
             ]
         );
         $builder->add(
@@ -114,7 +113,6 @@ class ConfigType extends AbstractType
                 'data' => isset($options['data']['ldap_auth_starttls']) ?
                     (bool) $options['data']['ldap_auth_starttls']
                     : false,
-                'empty_data' => false,
             ]
         );
 
@@ -249,7 +247,6 @@ class ConfigType extends AbstractType
                 'data' => isset($options['data']['ldap_auth_isactivedirectory']) ?
                     (bool) $options['data']['ldap_auth_isactivedirectory']
                     : false,
-                'empty_data' => false,
                 'required'   => false,
             ]
         );

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "mautic/composer-plugin": "^1.0",
     "symfony/form": "~3.4.0",
     "symfony/http-foundation": "~3.4.0",
-    "symfony/ldap": "~3.4.0",
+    "symfony/ldap": "~4.4.0",
     "symfony/translation": "~3.4.0",
     "symfony/security": "~3.4.0"
   },


### PR DESCRIPTION
With mautic 4, there are conflicts when trying to install symfony/ldap:~3.4.0 (because of security module requirements). I have updated the code to use the latest ldap module.

Tested against Cloudron LDAP.